### PR TITLE
Update .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # Local directories where inputs and outputs are found
 # When running on the refinement service, files will be mounted to the /input and /output directory of the container
-INPUT_DIR=input
-OUTPUT_DIR=output
+INPUT_DIR=/input
+OUTPUT_DIR=/output
 
 # This key is derived from the user file's original encryption key, automatically injected into the container by the refinement service
 # When developing locally, use any value for testing.


### PR DESCRIPTION
This PR fixes default input and output file paths in .env.example which point to location of the folders inside docker. It took me a while to figure out why my output wasn't being put into my local output folder.

p.s. No idea why this excessive change appeared in the end of the file, it's a github's quirk.